### PR TITLE
Remove placeholder.cpp from agentagenda module

### DIFF
--- a/cpp/agentagenda/src/placeholder.cpp
+++ b/cpp/agentagenda/src/placeholder.cpp
@@ -1,8 +1,0 @@
-// Placeholder implementation for agentagenda module
-// This will be implemented in Stage 3 - Application-specific modules
-
-namespace elizaos {
-    void agentagenda_placeholder() {
-        // Placeholder function to make library linkable
-    }
-}


### PR DESCRIPTION
This pull request removes the placeholder implementation in the `agentagenda` module, as it is no longer needed.

Code cleanup:

* [`cpp/agentagenda/src/placeholder.cpp`](diffhunk://#diff-f9ca8e61bab69bb2dc8a37bd0027a30879028d5d50aef3d9d8166137e74b9c16L1-L8): Removed the placeholder implementation for the `agentagenda` module, which included a placeholder function and comments indicating it was a temporary measure.